### PR TITLE
Do not override base type resources

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -141,6 +141,9 @@ class LinkItemResource5eActor {
   static prepareDerivedResources(wrapped, ...args) {
     wrapped(...args);
 
+    if (this.type === 'base')
+      return;
+
     const data = this.system;
     const items = this.items;
 


### PR DESCRIPTION
**token-mold** module tries to create dummy temporary actors of every type from [Actor.TYPES](https://foundryvtt.com/api/classes/client.Actor.html#TYPES) that contains also the `'base'` type. When that happen, we got: `Could not prepare data  tmp TypeError: Cannot read properties of undefined (reading 'push')`

Not sur if **token-mold** should skip that `'base'` type but it is easier and safer to protect **foundryvtt-link-item-resource-5e** code.